### PR TITLE
feat(invites): add mobile member code flow and dashboard sign-in guard

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -316,6 +316,30 @@ export const jobZoneReference = pgTable("job_zone_reference", {
 	svpRange: varchar("svp_range", { length: 25 }).notNull(),
 });
 
+// Invite codes for mobile member onboarding
+export const inviteCodes = pgTable("invite_codes", {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  invitationId: text("invitation_id").notNull(),
+  orgId: text("org_id").notNull(),
+  email: text().notNull(),
+  codeHash: text("code_hash").notNull(),
+  expiresAt: timestamp("expires_at", { mode: 'string' }).notNull(),
+  consumedAt: timestamp("consumed_at", { mode: 'string' }),
+  createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+  foreignKey({
+    columns: [table.invitationId],
+    foreignColumns: [baInvitations.id],
+    name: "invite_codes_invitation_id_fkey",
+  }).onDelete("cascade"),
+  foreignKey({
+    columns: [table.orgId],
+    foreignColumns: [baOrganizations.id],
+    name: "invite_codes_org_id_fkey",
+  }).onDelete("cascade"),
+  unique("invite_codes_unique_invitation").on(table.invitationId),
+]);
+
 export const baMembers = pgTable("ba_members", {
 	id: text().primaryKey().notNull(),
 	organizationId: text("organization_id").notNull(),

--- a/emails/index.ts
+++ b/emails/index.ts
@@ -10,6 +10,7 @@ export { NewDeviceEmail } from './new-device';
 export { SecurityAlertEmail } from './security-alert';
 export { OrganizationInviteEmail } from './organization-invite';
 export { OrganizationMagicLinkEmail } from './organization-magic-link';
+export { MemberInviteCodeEmail } from './member-invite-code';
 
 // React Email examples (for reference)
 export { default as NotionMagicLinkEmail } from './notion-magic-link';

--- a/emails/member-invite-code.tsx
+++ b/emails/member-invite-code.tsx
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from '@react-email/components';
+
+interface MemberInviteCodeEmailProps {
+  organizationName: string;
+  code: string;
+}
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+
+export const MemberInviteCodeEmail = ({
+  organizationName,
+  code,
+}: MemberInviteCodeEmailProps) => {
+  const previewText = `Your invite code for ${organizationName}`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white px-2 font-sans">
+          <Container className="mx-auto my-[40px] max-w-[465px] rounded border border-[#eaeaea] border-solid p-[20px]">
+            <Section className="mt-[32px]">
+              <Heading className="mx-0 my-[30px] p-0 text-center font-normal text-[24px] text-black">
+                Your invite to <strong>{organizationName}</strong>
+              </Heading>
+            </Section>
+            <Text className="text-[14px] text-black leading-[24px]">Hello,</Text>
+            <Text className="text-[14px] text-black leading-[24px]">
+              Use the code below in the SenseiiWyze mobile app to accept your invitation to
+              <strong> {organizationName}</strong>.
+            </Text>
+            <Section className="mt-[24px] mb-[24px] text-center">
+              <div className="inline-block rounded bg-gray-100 px-4 py-3 text-[18px] font-bold tracking-widest text-black">
+                {code}
+              </div>
+            </Section>
+            <Text className="text-[14px] text-black leading-[24px]">
+              Download the app and enter this code on the invitation screen. This code may expire, so please use it soon.
+            </Text>
+            <Hr className="mx-0 my-[26px] w-full border border-[#eaeaea] border-solid" />
+            <Text className="text-[#666666] text-[12px] leading-[24px]">
+              If you weren’t expecting this, you can ignore this email.
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+MemberInviteCodeEmail.PreviewProps = {
+  organizationName: 'Acme Corp',
+  code: 'ABC123',
+} as MemberInviteCodeEmailProps;
+
+export default MemberInviteCodeEmail;
+
+

--- a/src/app/api/mobile/accept-invite/route.ts
+++ b/src/app/api/mobile/accept-invite/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import bcrypt from "bcryptjs";
+import { checkFeatureUsage, organizationSeats } from "@/lib/autumn";
+
+export async function POST(request: Request) {
+  try {
+    const { code, email } = (await request.json()) as { code?: string; email?: string };
+
+    if (!code || !email) {
+      return NextResponse.json({ error: "missing_params" }, { status: 400 });
+    }
+
+    // 1) Find active code (latest unconsumed for this email)
+    const { data: codeRow, error: codeErr } = await (supabase as any)
+      .from('invite_codes')
+      .select('*')
+      .eq('email', email)
+      .is('consumed_at', null)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (codeErr || !codeRow) {
+      return NextResponse.json({ error: "invalid_or_expired" }, { status: 400 });
+    }
+
+    // Check expiry
+    if (codeRow.expires_at && new Date(codeRow.expires_at) < new Date()) {
+      return NextResponse.json({ error: "invalid_or_expired" }, { status: 400 });
+    }
+
+    // Verify code
+    const ok = await bcrypt.compare(code, codeRow.code_hash);
+    if (!ok) {
+      return NextResponse.json({ error: "invalid_or_expired" }, { status: 400 });
+    }
+
+    // 2) Validate invitation
+    const { data: invite, error: inviteErr } = await (supabase as any)
+      .from('ba_invitations')
+      .select('*')
+      .eq('id', codeRow.invitation_id)
+      .maybeSingle();
+
+    if (inviteErr || !invite || invite.status !== "pending" || invite.email !== email) {
+      return NextResponse.json({ error: "invalid_or_expired" }, { status: 400 });
+    }
+
+    // 3) Seat check via Autumn
+    // Customer is organization id (org-based billing)
+    const orgId = invite.organization_id as string;
+    const seatData = await checkFeatureUsage(orgId, organizationSeats.id);
+
+    if (!seatData || !seatData?.allowed) {
+      return NextResponse.json({ error: "insufficient_seats" }, { status: 402 });
+    }
+
+    // 4) Ensure user exists (mobile-only flag)
+    const { data: existing, error: userErr } = await (supabase)
+      .from('ba_users')
+      .select('id')
+      .eq('email', email)
+      .maybeSingle();
+
+    let userId = existing?.id as string | undefined;
+    if (!existing) {
+      const now = new Date().toISOString();
+      const uid = crypto.randomUUID();
+      const { error: insertErr } = await (supabase as any)
+        .from('ba_users')
+        .insert([{ id: uid, name: email, email, email_verified: false, created_at: now, updated_at: now, role: 'member' }]);
+      if (insertErr) {
+        return NextResponse.json({ error: "server_error" }, { status: 500 });
+      }
+      userId = uid;
+    }
+        // After inserting into ba_users:
+    const { data: existingProfile } = await (supabase as any).from('profiles').select('id').eq('email', email).maybeSingle();
+
+    let profileId = existingProfile?.id;
+    if (!profileId) {
+    const { data: created, error: createErr } = await (supabase as any)
+    .from('profiles')
+    .insert({
+        email,
+        name: email,
+        user_role: 'member',          
+        is_onboarding: false,       
+        onboarding_step: -1
+    })
+    .select('id')
+    .single();
+    if (createErr) throw createErr;
+       profileId = created.id;
+    }
+
+    const { error: linkErr } = await (supabase as any)
+    .from('ba_users')
+    .update({ profile_id: profileId, is_dashboard_user: false }) // ensure mobile-only
+    .eq('id', userId);
+    if (linkErr) throw linkErr;
+
+    // 5) Add member to organization (server-side) and mark invitation accepted
+    // Ensure membership does not already exist
+    const { data: existingMember } = await (supabase as any)
+      .from('ba_members')
+      .select('id')
+      .eq('organization_id', orgId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (!existingMember) {
+      const { error: insertMemberErr } = await (supabase as any)
+        .from('ba_members')
+        .insert([{ id: crypto.randomUUID(), organization_id: orgId, user_id: userId, role: 'member', created_at: new Date().toISOString() }]);
+      if (insertMemberErr) {
+        return NextResponse.json({ error: 'server_error' }, { status: 500 });
+      }
+    }
+
+    // Update invitation status to accepted
+    await (supabase as any)
+      .from('ba_invitations')
+      .update({ status: 'accepted' })
+      .eq('id', codeRow.invitation_id);
+
+    // 6) Mark code consumed
+    await (supabase as any)
+      .from('invite_codes')
+      .update({ consumed_at: new Date().toISOString() })
+      .eq('id', codeRow.id);
+
+    return NextResponse.json({ success: true, orgId, userId });
+  } catch (error) {
+    console.error("/api/mobile/accept-invite error", error);
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
+  }
+}
+
+

--- a/src/app/api/mobile/organization/[orgId]/route.ts
+++ b/src/app/api/mobile/organization/[orgId]/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { checkFeatureUsage } from "@/lib/autumn";
+import { supabase } from "@/lib/supabase";
+import bcrypt from "bcryptjs";
+import { sendMemberInviteCodeEmail } from "@/lib/email";
+
+function generateCode(length = 6) {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let out = "";
+  for (let i = 0; i < length; i++) out += chars[Math.floor(Math.random() * chars.length)];
+  return out;
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ orgId: string }> }
+) {
+  try {
+    const { email, role, name } = await req.json();
+    const organizationId = (await params).orgId;
+
+    // Seat check via Autumn
+    const seatUsage = await checkFeatureUsage(organizationId, "organization_seats");
+    if (!seatUsage || !seatUsage.allowed) {
+      return NextResponse.json(
+        {
+          error: "No available seats",
+          message:
+            "Your organization has reached its seat limit. Please upgrade your plan to invite more members.",
+          remainingSeats: seatUsage?.balance || 0,
+          totalSeats: seatUsage?.included_usage || 0,
+          usage: seatUsage?.usage || 0,
+          unlimited: seatUsage?.unlimited || false,
+        },
+        { status: 403 }
+      );
+    }
+
+    // Create the Better Auth invitation
+    const invitation = await auth.api.createInvitation({
+      body: { email, role, organizationId, resend: true },
+      headers: await headers(),
+    });
+
+    // Fetch organization name for email context
+    let organizationName = "Your Organization";
+    try {
+      const { data: org } = await (supabase as any)
+        .from("ba_organizations")
+        .select("name")
+        .eq("id", organizationId)
+        .maybeSingle();
+      if (org?.name) organizationName = org.name as string;
+    } catch {}
+
+    // Generate member code (raw + hash) and store in invite_codes
+    const code = generateCode(6);
+    const codeHash = await bcrypt.hash(code, 10);
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+    const { error: insertErr } = await (supabase as any)
+      .from("invite_codes")
+      .insert([
+        {
+          invitation_id: invitation.id,
+          org_id: organizationId,
+          email,
+          code_hash: codeHash,
+          expires_at: expiresAt,
+        },
+      ]);
+    if (insertErr) {
+      return NextResponse.json({ error: "Failed to create invite code" }, { status: 500 });
+    }
+
+    // Send email with raw code
+    const sendRes = await sendMemberInviteCodeEmail({
+      email,
+      organizationName,
+      code,
+    });
+    if (sendRes.error) {
+      return NextResponse.json({ error: "Failed to send invite code email" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, invitationId: invitation.id });
+  } catch (error) {
+    console.error("Mobile org invitation error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+

--- a/src/hooks/useUserImport.ts
+++ b/src/hooks/useUserImport.ts
@@ -111,7 +111,12 @@ export function useUserImport() {
         const i = idx++;
         const row = rows[i];
         try {
-          const res = await fetch(`/api/organization/${activeOrganizationId}`, {
+          const isMember = row.role && row.role.includes('member') && !row.role.includes('admin');
+          const endpoint = isMember
+            ? `/api/mobile/organization/${activeOrganizationId}`
+            : `/api/organization/${activeOrganizationId}`;
+
+          const res = await fetch(endpoint, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({

--- a/src/types/user-import.ts
+++ b/src/types/user-import.ts
@@ -1,6 +1,6 @@
 export type InviteRow = {
   email: string;
-  role?: "admin-executive" | "admin-manager";
+  role?: "admin-executive" | "admin-manager" | "member";
   first_name?: string;
   last_name?: string;
   title?: string;

--- a/src/utils/user-import.ts
+++ b/src/utils/user-import.ts
@@ -7,6 +7,8 @@ export function toRole(v: string | undefined | null): InviteRow["role"] {
   if (s === "admin-executive") return "admin-executive";
   if (s === "admin-manager" || s === "manager" || s === "admin")
     return "admin-manager";
+  if (s === "member" || s === "mobile" || s === "user")
+    return "member";
   return "admin-executive";
 }
 


### PR DESCRIPTION
- Add MemberInviteCodeEmail template and sender helper
- Create POST /api/mobile/organization/[orgId] to create BA invitation, generate/store code, and email it
- Implement POST /api/mobile/accept-invite to verify code, enforce seats, create/link member profile, add ba_members, accept invite, consume code
- Update useUserImport to route member rows to mobile endpoint; admins use existing flow
- Support member role in CSV/XLSX parsing and types
- Block mobile-only users on login page via is_dashboard_user pre-check